### PR TITLE
필요 없는 권한 삭제 & 클릭 리스너 기본 생성자 추가

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-
     <application
         android:name="com.hig.iga_works_sdk.IGASDKApplication"
         android:allowBackup="true"

--- a/app/src/main/java/com/hig/iga_works/MainActivity.java
+++ b/app/src/main/java/com/hig/iga_works/MainActivity.java
@@ -27,12 +27,11 @@ public class MainActivity extends AppCompatActivity {
         requestLocationPermission();
 
         Button buttonMenu = findViewById(R.id.button_menu);
-        buttonMenu.setOnClickListener(new IGAMenuClickListener(TAG + " - Click Button") {
+        buttonMenu.setOnClickListener(new IGAMenuClickListener() {
             @Override
             public void onClick(View view) {
                 super.onClick(view);
-                Log.d(TAG, "IGA Clicked Listener called: ");
-                Toast.makeText(MainActivity.this.getApplicationContext(), "button is clicked", Toast.LENGTH_LONG).show();
+                // 사용자가 하고 싶은 행위
             }
         });
 

--- a/iga_works_sdk/src/main/java/com/hig/iga_works_sdk/IGAMenuClickListener.java
+++ b/iga_works_sdk/src/main/java/com/hig/iga_works_sdk/IGAMenuClickListener.java
@@ -10,6 +10,10 @@ public abstract class IGAMenuClickListener implements View.OnClickListener {
     private static final String TAG = "IGAClickListener";
     private final String event;
 
+    public IGAMenuClickListener() {
+        this.event = "click";
+    }
+
     public IGAMenuClickListener(String event) {
         this.event = event;
     }


### PR DESCRIPTION
IGASDK에서 권한 선언했으므로 권한 삭제

클릭 리스너에 기본 생성자 추가해서 다형성을 줬다. 만약, 사용자가 이벤트를 입력하고 싶지 않으면 기본 생성자를 사용하면 된다.
